### PR TITLE
Remove ability to change FU BYOS SAIL object image

### DIFF
--- a/objects/ship/fu_byostechstation/fu_byostechstation.object.patch
+++ b/objects/ship/fu_byostechstation/fu_byostechstation.object.patch
@@ -33,15 +33,6 @@
   ],
 
   [
-    { "op": "test", "path": "/animationScripts" },
-    { "op": "add", "path": "/animationScripts/-", "value": "/objects/scripts/changeObjectSprite.lua" }
-  ],
-  [
-    { "op": "test", "path": "/animationScripts", "inverse": true },
-    { "op": "add", "path": "/animationScripts", "value": [ "/objects/scripts/changeObjectSprite.lua" ] }
-  ],
-
-  [
     { "op": "test", "path": "/scripts" },
     { "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
   ],

--- a/objects/ship/fu_byostechstation/fu_byostechstationdeco.object.patch
+++ b/objects/ship/fu_byostechstation/fu_byostechstationdeco.object.patch
@@ -33,15 +33,6 @@
   ],
 
   [
-    { "op": "test", "path": "/animationScripts" },
-    { "op": "add", "path": "/animationScripts/-", "value": "/objects/scripts/changeObjectSprite.lua" }
-  ],
-  [
-    { "op": "test", "path": "/animationScripts", "inverse": true },
-    { "op": "add", "path": "/animationScripts", "value": [ "/objects/scripts/changeObjectSprite.lua" ] }
-  ],
-
-  [
     { "op": "test", "path": "/scripts" },
     { "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
   ],


### PR DESCRIPTION
Removes the required script to change the SAIL objects image because it conflicts with the racialiser object image changes