### PR TITLE
Add FU Precursor Dungeon

### DIFF
--- a/scriptedArtificialIntelligenceLattice/ai/missionsTableForMods.config
+++ b/scriptedArtificialIntelligenceLattice/ai/missionsTableForMods.config
@@ -33,6 +33,7 @@
     ["shoggothmission", "shoggoth_unlocknew"],
     ["shoggothmission", "shoggoth_wagner"],
     ["missionpenguin1", "scienceoutpost_boss1"],
+    ["precursordungeon", "precursor_unlock"],
 
     //Gyrusens+ stuff
     ["jyinkumission", "jyinquest6"],


### PR DESCRIPTION
The missions table was missing an unlock for FU's new dungeon. (It also shows the shoggoth mission twice, but I'm not sure there's anything to be done about that.)